### PR TITLE
Update a bunch of stuff that really should be fixed before this is used by many people

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,11 @@
 buildscript {
     repositories {
         maven { url = 'https://files.minecraftforge.net/maven' }
-        jcenter()
         mavenCentral()
         maven {url='https://repo.spongepowered.org/maven'}
     }
     dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '4.1.+', changing: true
         classpath 'gradle.plugin.com.matthewprenger:CurseGradle:1.1.0'
         classpath 'com.wynprice.cursemaven:CurseMaven:2.1.3'
         classpath group: 'org.spongepowered', name: 'mixingradle', version: '0.7-SNAPSHOT'
@@ -14,20 +13,22 @@ buildscript {
 }
 
 plugins {
-    id "com.wynprice.cursemaven" version "2.1.3"
+    id'com.github.gmazzo.buildconfig' version '3.0.1'
 }
 
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'com.matthewprenger.cursegradle'
-apply plugin: 'com.wynprice.cursemaven'
 apply plugin: 'org.spongepowered.mixin'
+apply plugin: 'idea'
+apply plugin: 'eclipse'
 
-group = 'com.kotakotik' // TODO: change this!
+group = "mod.${author}.${modid}"
 version = "${minecraft_version}-${mod_version}"
 archivesBaseName = modid
 
-sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
+java.toolchain.languageVersion = JavaLanguageVersion.of(8) // Mojang ships Java 8 to end users, so your mod should target Java 8.
 
+println('Java: ' + System.getProperty('java.version') + ' JVM: ' + System.getProperty('java.vm.version') + '(' + System.getProperty('java.vendor') + ') Arch: ' + System.getProperty('os.arch'))
 minecraft {
     mappings channel: "${mappings_channel}", version: "${mappings_version}"
 
@@ -36,12 +37,10 @@ minecraft {
     runs {
         client {
             workingDirectory project.file('run')
-
-            jvmArgs "-Dmixin.env.disableRefMap=true"
-            arg "-mixin.config=youraddon.mixins.json" // TODO: change this
-
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
+            arg "-mixin.config=${modid}.mixins.json".toString()
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-
             property 'forge.logging.console.level', 'debug'
 
             mods {
@@ -53,12 +52,10 @@ minecraft {
 
         server {
             workingDirectory project.file('server')
-
-            jvmArgs "-Dmixin.env.disableRefMap=true"
-            arg "-mixin.config=youraddon.mixins.json" // TODO: change this
-
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
+            arg "-mixin.config=${modid}.mixins.json".toString()
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-
             property 'forge.logging.console.level', 'debug'
 
             mods {
@@ -70,14 +67,12 @@ minecraft {
 
         data {
             workingDirectory project.file('run')
-
-            jvmArgs "-Dmixin.env.disableRefMap=true"
-
+            property 'mixin.env.remapRefMap', 'true'
+            property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
-
             property 'forge.logging.console.level', 'debug'
 
-            args '--mod', modid, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
+            args "--mod", modid, "--all", "--output", file('src/generated/resources/'), "--existing", file('src/main/resources/')
 
             mods {
                 "${modid}" {
@@ -100,6 +95,10 @@ repositories {
             includeGroup "curse.maven"
         }
     }
+    maven {
+        url 'https://jitpack.io/'
+    }
+
 }
 
 dependencies {
@@ -111,17 +110,19 @@ dependencies {
     annotationProcessor 'org.spongepowered:mixin:0.8:processor'
 }
 
+compileJava.options.encoding = 'UTF-8'
+
 jar {
     manifest {
         attributes([
                 "Specification-Title"     : modid,
-                "Specification-Vendor"    : "You", // TODO: change this!
+                "Specification-Vendor"    : author,
                 "Specification-Version"   : "1", // We are version 1 of ourselves
                 "Implementation-Title"    : project.name,
                 "Implementation-Version"  : project.version,
-                "Implementation-Vendor"   : "You", // TODO: change this!
+                "Implementation-Vendor"   : author,
                 "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
-                "MixinConfigs"            : "${modid}.mixins.json" // TODO: change youraddon.mixins.json
+                "MixinConfigs"            : "${modid}.mixins.json"
         ])
     }
 }
@@ -148,3 +149,36 @@ artifacts {
 build.dependsOn deobfJar
 
 jar.finalizedBy('reobfJar')
+
+
+def getGitHash = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
+def hasUnstaged = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'status', '--porcelain'
+        standardOutput = stdout
+    }
+    def result = stdout.toString().replaceAll("M gradlew", "").trim()
+    if (!result.isEmpty())
+        println("Found stageable results:\n${result}\n")
+    return !result.isEmpty()
+}
+
+buildConfig {
+    buildConfigField 'String', 'MODID', "\"${modid}\""
+    buildConfigField 'String', 'VERSION', "\"${project.version}\""
+    def gitstage = "\"${getGitHash()}" + (hasUnstaged() ? "-modified" : "") + "\""
+    println("Using git stage ${gitstage}")
+    buildConfigField "String", "GITHASH", gitstage
+
+    version = project.version
+    packageName = project.group
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,12 +8,14 @@ forge_version=36.1.32
 # TODO: change this!
 mod_version=VERSION
 # TODO: change this!
-modid=youraddon
+modid=yourmodid
+# TODO: YOU
+author=yourname
 
 # Mappings
-mappings_channel = snapshot
+mappings_channel = official
 # probably update this? https://maven.tterrag.com/de/oceanlabs/mcp/mcp_snapshot/
-mappings_version=20210601-mixed-1.16.5
+mappings_version=1.16.5
 
 # Mod versions
 # probably update this https://www.curseforge.com/minecraft/mc-mods/create/files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/mod/yourname/yourmodid/CreateAddon.java
+++ b/src/main/java/mod/yourname/yourmodid/CreateAddon.java
@@ -1,6 +1,6 @@
-package com.example.createaddontemplate;
+package mod.yourname.yourmodid;
 
-import com.example.createaddontemplate.register.*;
+import mod.yourname.yourmodid.register.*;
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.simibubi.create.repack.registrate.util.NonNullLazyValue;
 import net.minecraftforge.api.distmarker.Dist;
@@ -14,17 +14,15 @@ import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-// TODO: rename this class! and package name!
-@Mod(CreateAddon.modid)
+// TODO: rename this class! and package name! package name should be mod.yourname.modid, see import of BuildConfig class
+@Mod(BuildConfig.MODID)
 public class CreateAddon {
 
     // Directly reference a log4j logger.
-    private static final Logger LOGGER = LogManager.getLogger();
-
-    public static final String modid = "youraddon"; // TODO: change this!
+    private static final Logger LOGGER = LogManager.getLogger(BuildConfig.MODID);
     public static IEventBus modEventBus;
 
-    public static final NonNullLazyValue<CreateRegistrate> registrate = CreateRegistrate.lazy(modid);
+    public static final NonNullLazyValue<CreateRegistrate> registrate = CreateRegistrate.lazy(BuildConfig.MODID);
 
     public CreateAddon() {
         modEventBus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/src/main/java/mod/yourname/yourmodid/mixin/README.txt
+++ b/src/main/java/mod/yourname/yourmodid/mixin/README.txt
@@ -1,0 +1,2 @@
+in this directory, you can only put mixin classes. Any other classes would crash.
+This file is here so git tracks the directory. Therefore, this file can be removed.

--- a/src/main/java/mod/yourname/yourmodid/register/ModBlocks.java
+++ b/src/main/java/mod/yourname/yourmodid/register/ModBlocks.java
@@ -1,8 +1,8 @@
-package com.example.createaddontemplate.register;
+package mod.yourname.yourmodid.register;
 
 import com.simibubi.create.foundation.data.CreateRegistrate;
 
-public class ModEntities {
+public class ModBlocks {
     public static void register(CreateRegistrate registrate) {
 
     }

--- a/src/main/java/mod/yourname/yourmodid/register/ModEntities.java
+++ b/src/main/java/mod/yourname/yourmodid/register/ModEntities.java
@@ -1,8 +1,8 @@
-package com.example.createaddontemplate.register;
+package mod.yourname.yourmodid.register;
 
 import com.simibubi.create.foundation.data.CreateRegistrate;
 
-public class ModTiles {
+public class ModEntities {
     public static void register(CreateRegistrate registrate) {
 
     }

--- a/src/main/java/mod/yourname/yourmodid/register/ModItems.java
+++ b/src/main/java/mod/yourname/yourmodid/register/ModItems.java
@@ -1,15 +1,15 @@
-package com.example.createaddontemplate.register;
+package mod.yourname.yourmodid.register;
 
-import com.example.createaddontemplate.CreateAddon;
 import com.simibubi.create.AllItems;
 import com.simibubi.create.foundation.data.CreateRegistrate;
+import mod.yourname.yourmodid.BuildConfig;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 
 public class ModItems {
-    public static ItemGroup itemGroup = new ItemGroup(CreateAddon.modid) {
+    public static ItemGroup itemGroup = new ItemGroup(BuildConfig.MODID) {
         @Override
-        public ItemStack createIcon() {
+        public ItemStack makeIcon() {
             return new ItemStack(AllItems.WRENCH.get());
         }
     };

--- a/src/main/java/mod/yourname/yourmodid/register/ModPartials.java
+++ b/src/main/java/mod/yourname/yourmodid/register/ModPartials.java
@@ -1,14 +1,13 @@
-package com.example.createaddontemplate.register;
+package mod.yourname.yourmodid.register;
 
-import com.example.createaddontemplate.CreateAddon;
 import com.jozufozu.flywheel.core.PartialModel;
-import com.simibubi.create.AllBlockPartials;
 import com.simibubi.create.Create;
+import mod.yourname.yourmodid.BuildConfig;
 import net.minecraft.util.ResourceLocation;
 
 public class ModPartials {
     public static PartialModel get(String name) {
-        return new PartialModel(new ResourceLocation(CreateAddon.modid, "block/" + name));
+        return new PartialModel(new ResourceLocation(BuildConfig.MODID, "block/" + name));
     }
 
     public static PartialModel getCreate(String name) {
@@ -16,7 +15,7 @@ public class ModPartials {
     }
 
     public static PartialModel getEntity(String name) {
-        return new PartialModel(new ResourceLocation(CreateAddon.modid, "entity/" + name));
+        return new PartialModel(new ResourceLocation(BuildConfig.MODID, "entity/" + name));
     }
 
     public static PartialModel getEntityCreate(String name) {

--- a/src/main/java/mod/yourname/yourmodid/register/ModPonder.java
+++ b/src/main/java/mod/yourname/yourmodid/register/ModPonder.java
@@ -1,10 +1,8 @@
-package com.example.createaddontemplate.register;
+package mod.yourname.yourmodid.register;
 
-import com.example.createaddontemplate.CreateAddon;
 import com.simibubi.create.foundation.data.CreateRegistrate;
 import com.simibubi.create.foundation.ponder.PonderRegistry;
-import com.simibubi.create.foundation.ponder.content.PonderTag;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import mod.yourname.yourmodid.BuildConfig;
 import net.minecraftforge.fml.event.lifecycle.GatherDataEvent;
 
 public class ModPonder {
@@ -17,7 +15,7 @@ public class ModPonder {
         PonderRegistry.provideLangEntries().getAsJsonObject().entrySet().forEach(e -> {
             String k = e.getKey();
             String v = e.getValue().getAsString();
-            if (k.contains(CreateAddon.modid + ".")) {
+            if (k.contains(BuildConfig.MODID + ".")) {
                 registrate.addRawLang(k, v);
             }
         });

--- a/src/main/java/mod/yourname/yourmodid/register/ModTiles.java
+++ b/src/main/java/mod/yourname/yourmodid/register/ModTiles.java
@@ -1,8 +1,8 @@
-package com.example.createaddontemplate.register;
+package mod.yourname.yourmodid.register;
 
 import com.simibubi.create.foundation.data.CreateRegistrate;
 
-public class ModBlocks {
+public class ModTiles {
     public static void register(CreateRegistrate registrate) {
 
     }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -37,7 +37,7 @@ description = '''
 Your Create addon description!
 '''
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
-# TODO: change all of the depdendencies.createaddon to dependencies.yourmodid !
+# TODO: change all of the depdendencies.yourmodid to dependencies.(your modid) !
 [[dependencies.yourmodid]] #optional
 # the modid of the dependency
 modId = "forge" #mandatory

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -9,13 +9,13 @@ modLoader = "javafml" #mandatory
 loaderVersion = "[36,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
-license = "All rights reserved"
+license = "MIT License"
 # A URL to refer people to when problems occur with this mod
 #issueTrackerURL="http://my.issue.tracker/" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod
-modId = "youraddon" #mandatory TODO: change this!
+modId = "yourmodid" #mandatory TODO: change this!
 # The version number of the mod - there's a few well known ${} variables useable here or just hardcode it
 # ${file.jarVersion} will substitute the value of the Implementation-Version as read from the mod's JAR file metadata
 # see the associated build.gradle script for how to populate this completely automatically during a build
@@ -38,7 +38,7 @@ Your Create addon description!
 '''
 # A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
 # TODO: change all of the depdendencies.createaddon to dependencies.yourmodid !
-[[dependencies.createaddon]] #optional
+[[dependencies.yourmodid]] #optional
 # the modid of the dependency
 modId = "forge" #mandatory
 # Does this dependency have to exist - if not, ordering below must be specified
@@ -50,14 +50,14 @@ ordering = "NONE"
 # Side this dependency is applied on - BOTH, CLIENT or SERVER
 side = "BOTH"
 # Here's another dependency
-[[dependencies.createaddon]]
+[[dependencies.yourmodid]]
 modId = "minecraft"
 mandatory = true
 # This version range declares a minimum of the current minecraft version up to but not including the next major version
 versionRange = "[1.16.5,1.17)"
 ordering = "NONE"
 side = "BOTH"
-[[dependencies.createaddon]]
+[[dependencies.yourmodid]]
 modId = "create"
 mandatory = true
 versionRange = "mc1.16.5_v0.3.1c" # TODO: probably update this, maybe to a version range https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html

--- a/src/main/resources/yourmodid.mixins.json
+++ b/src/main/resources/yourmodid.mixins.json
@@ -1,8 +1,8 @@
 {
   "required": true,
-  "package": "com.example.createaddontemplate.mixin",
+  "package": "mod.yourname.yourmodid.mixin",
   "compatibilityLevel": "JAVA_8",
-  "refmap": "hackforge.refmap.json",
+  "refmap": "modid.refmap.json",
   "mixins": [
   ],
   "injectors": {

--- a/src/main/resources/yourmodid.mixins.json
+++ b/src/main/resources/yourmodid.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "package": "mod.yourname.yourmodid.mixin",
   "compatibilityLevel": "JAVA_8",
-  "refmap": "modid.refmap.json",
+  "refmap": "yourmodid.refmap.json",
   "mixins": [
   ],
   "injectors": {


### PR DESCRIPTION
- Update gradle to 6.9
- updated to forge gradle 4.1
- update mappings to official, as that is what create now uses
- update disableRefMap to remapRefMap
- added BuildConfig
- reduced the places in which to change stuff
- unified the stuff to change to yourname/yourmodid to make find/replace possible
- added readme to mixin folder so the folder is tracked on github
- fixed mixin definition (welp, i know i borked it myself in cog tweaker)
- added debug print in build.gradle to display java environment (makes debugging easier as it tells about incorrect setup)
- removed legacy cursemaven definition